### PR TITLE
Gradle 7.0 disallowed to access maven repo without https.

### DIFF
--- a/fabric-mod.gradle
+++ b/fabric-mod.gradle
@@ -8,7 +8,7 @@ buildscript {
 		}
 		maven {
 			name = 'TerraformersMC'
-			url = 'http://maven.terraformersmc.com/'
+			url = 'https://maven.terraformersmc.com/'
 		}
 		gradlePluginPortal()
 		mavenLocal()


### PR DESCRIPTION
I am trying to fix an issue of modmenu(https://github.com/TerraformersMC/ModMenu/issues/259) to make it work on minecraft 21w20a, and I found that to update to 21w20a, we need to update Java16 and Gradle 7.0 (if you are using gradle 6.5, you will got an "Unsupported class major version 60"), but Gradle 7.0 disallowed to access maven repo without https.