### PR TITLE
Fixed "Could not find org.ajoberstar.grgit:grgit-core:4.1.0." upon building ModMenu

### DIFF
--- a/ferry.gradle
+++ b/ferry.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath "net.dumbcode.gradlehook:GradleHook:1.3.1"
         classpath "gradle.plugin.com.matthewprenger:CurseGradle:1.4.0"
         classpath "org.kohsuke:github-api:1.114"
-        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
+        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.1"
         classpath "com.modrinth.minotaur:Minotaur:2.8.7"
     }
 }


### PR DESCRIPTION
The referenced package doesn't exist in repo.maven.apache.org, but a minor revision does.